### PR TITLE
Add usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # cciehl
+
+此仓库包含一个示例 VS Code 插件 **AI 开发助理**。要在本地运行，请阅读 [my-ai-assistant/README.md](my-ai-assistant/README.md)。

--- a/my-ai-assistant/README.md
+++ b/my-ai-assistant/README.md
@@ -1,0 +1,22 @@
+# AI 开发助理 VS Code 插件
+
+这是一个示例 VS Code 插件，提供生成任务、扫描代码、生成报告和发布文章的命令。
+
+## 本地运行
+
+1. 安装依赖并编译
+   ```bash
+   cd my-ai-assistant
+   npm install
+   npm run compile
+   ```
+2. 设置 OpenAI API 密钥（请将 `OPENAI_API_KEY` 替换为你的实际密钥）
+   ```bash
+   export OPENAI_API_KEY=your-key-here
+   ```
+3. 在 VS Code 中按 <kbd>F5</kbd> 启动调试，会打开新的 Extension Development Host 窗口。
+4. 在命令面板中执行以下任一命令体验插件：
+   - `AI: 生成代码/测试/文档`
+   - `AI: 扫描并质量提醒`
+   - `AI: 自动生成报告`
+   - `AI: 发布公众号文章`

--- a/my-ai-assistant/package.json
+++ b/my-ai-assistant/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "my-ai-assistant",
+  "displayName": "AI 开发助理",
+  "version": "0.0.1",
+  "publisher": "your-name",
+  "engines": { "vscode": "^1.60.0" },
+  "activationEvents": [
+    "onCommand:ai.generateTask",
+    "onCommand:ai.scanCode",
+    "onCommand:ai.generateDocs",
+    "onCommand:ai.publishArticle"
+  ],
+  "main": "./out/extension.js",
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "dependencies": {
+    "openai": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.60.0",
+    "typescript": "^4.4.3",
+    "vscode": "^1.1.37"
+  },
+  "contributes": {
+    "commands": [
+      {
+        "command": "ai.generateTask",
+        "title": "AI: 生成代码/测试/文档"
+      },
+      {
+        "command": "ai.scanCode",
+        "title": "AI: 扫描并质量提醒"
+      },
+      {
+        "command": "ai.generateDocs",
+        "title": "AI: 自动生成报告"
+      },
+      {
+        "command": "ai.publishArticle",
+        "title": "AI: 发布公众号文章"
+      }
+    ]
+  }
+}

--- a/my-ai-assistant/src/api.ts
+++ b/my-ai-assistant/src/api.ts
@@ -1,0 +1,17 @@
+import { Configuration, OpenAIApi } from 'openai';
+
+const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAIApi(configuration);
+
+export async function callOpenAI(prompt: string): Promise<string> {
+  const resp = await openai.createCompletion({
+    model: 'code-davinci-002',
+    prompt,
+    temperature: 0.2,
+    max_tokens: 1024,
+    top_p: 1,
+    frequency_penalty: 0,
+    presence_penalty: 0
+  });
+  return resp.data.choices[0].text || '';
+}

--- a/my-ai-assistant/src/commands/generateDocs.ts
+++ b/my-ai-assistant/src/commands/generateDocs.ts
@@ -1,0 +1,3 @@
+export async function generateDocs() {
+  // TODO: Implement command logic
+}

--- a/my-ai-assistant/src/commands/generateTask.ts
+++ b/my-ai-assistant/src/commands/generateTask.ts
@@ -1,0 +1,3 @@
+export async function generateTask() {
+  // TODO: Implement command logic
+}

--- a/my-ai-assistant/src/commands/publishArticle.ts
+++ b/my-ai-assistant/src/commands/publishArticle.ts
@@ -1,0 +1,3 @@
+export async function publishArticle() {
+  // TODO: Implement command logic
+}

--- a/my-ai-assistant/src/commands/scanCode.ts
+++ b/my-ai-assistant/src/commands/scanCode.ts
@@ -1,0 +1,3 @@
+export async function scanCode() {
+  // TODO: Implement command logic
+}

--- a/my-ai-assistant/src/extension.ts
+++ b/my-ai-assistant/src/extension.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { callOpenAI } from './api';
+import prompts from './prompts';
+
+export function activate(context: vscode.ExtensionContext) {
+  // 生成任务（代码/测试/文档）
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ai.generateTask', async () => {
+      const desc = await vscode.window.showInputBox({ prompt: '描述你的任务' });
+      if (!desc) { return; }
+      const prompt = prompts.generateTask.replace('{{task}}', desc);
+      const result = await callOpenAI(prompt);
+      vscode.window.showInformationMessage('AI 助理已生成结果，打开输出面板查看。');
+      const out = vscode.window.createOutputChannel('AI Assistant');
+      out.show(); out.appendLine(result);
+    })
+  );
+
+  // 扫描代码质量
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ai.scanCode', async () => {
+      const prompt = prompts.scanCode;
+      const code = vscode.workspace.textDocuments.map(d => d.getText()).join('\n\n');
+      const result = await callOpenAI(prompt + '\n\n```ts\n' + code + '\n```');
+      const out = vscode.window.createOutputChannel('AI Scan');
+      out.show(); out.appendLine(result);
+    })
+  );
+
+  // 自动生成报告文档
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ai.generateDocs', async () => {
+      const desc = await vscode.window.showInputBox({ prompt: '报告主题（如“边缘云资源规划”）' });
+      if (!desc) { return; }
+      const prompt = prompts.generateDocs.replace('{{topic}}', desc);
+      const result = await callOpenAI(prompt);
+      const doc = await vscode.workspace.openTextDocument({ language: 'markdown', content: result });
+      vscode.window.showTextDocument(doc);
+    })
+  );
+
+  // 发布公众号文章
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ai.publishArticle', async () => {
+      const title = await vscode.window.showInputBox({ prompt: '文章标题' });
+      const body = await vscode.window.showInputBox({ prompt: '文章内容（Markdown）', value: '' });
+      if (!title || !body) { return; }
+      const prompt = prompts.publishArticle
+        .replace('{{title}}', title)
+        .replace('{{body}}', body);
+      await callOpenAI(prompt);
+      vscode.window.showInformationMessage('文章已通过 API 提交，稍后检查公众号后台。');
+    })
+  );
+}
+
+export function deactivate() {}

--- a/my-ai-assistant/src/prompts.ts
+++ b/my-ai-assistant/src/prompts.ts
@@ -1,0 +1,33 @@
+export default {
+  generateTask: `
+给你一段任务描述，生成：
+1. 对应的 TypeScript/JavaScript 代码补丁或测试用例
+2. 相关注释或 README 片段
+3. 合理的 commit message 或 PR 描述
+
+任务：{{task}}
+`,
+  scanCode: `
+帮我扫描下面的 TypeScript 代码，指出：
+- 变量/函数拼写或风格问题
+- 复杂度过高的函数需重构
+- 缺失的测试用例建议
+输出分点列表。
+`,
+  generateDocs: `
+请根据以下主题，生成一份结构完整的 Markdown 报告：
+主题：{{topic}}
+目录：
+1. 背景与问题
+2. 方法与思路
+3. 关键步骤
+4. 结论与建议
+`,
+  publishArticle: `
+你是微信公众号自动排版助手。
+根据下面的标题和 Markdown 正文，生成符合公众号格式的图文消息 JSON：
+标题：《{{title}}》
+正文：
+{{body}}
+`
+};

--- a/my-ai-assistant/tsconfig.json
+++ b/my-ai-assistant/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "out",
+    "lib": ["es6"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary
- document how to run the AI assistant extension locally

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('my-ai-assistant/package.json','utf8')); console.log('valid');"`
- `npm run compile` *(fails: Cannot find module 'openai')*