### PR TITLE
Add backend server skeleton

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,17 @@
+# Content Automation Server
+
+This directory contains a minimal Node.js + Express backend implementing the API described in the requirements document. It includes MongoDB models, task scheduling with node-schedule and basic OpenAI integration.
+
+To run in development:
+
+```bash
+npm install
+npm run dev
+```
+
+Environment variables:
+
+- `OPENAI_API_KEY` – API key for OpenAI
+- `MONGO_URI` – MongoDB connection string (defaults to local instance)
+- `PORT` – HTTP port (default 3000)
+```

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "content-automation-server",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node-dev src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.0.4",
+    "node-schedule": "^2.1.0",
+    "openai": "^4.0.0",
+    "dotenv": "^16.0.3",
+    "cors": "^2.8.5",
+    "body-parser": "^1.20.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4",
+    "ts-node-dev": "^2.0.0",
+    "@types/express": "^4.17.17",
+    "@types/node": "^18.15.11"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import bodyParser from 'body-parser';
+import dotenv from 'dotenv';
+import configRoutes from './routes/config';
+import tasksRoutes from './routes/tasks';
+import platformsRoutes from './routes/platforms';
+import { loadTasks } from './services/scheduler';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(bodyParser.json());
+
+app.use('/api/config', configRoutes);
+app.use('/api/tasks', tasksRoutes);
+app.use('/api/platforms', platformsRoutes);
+
+const PORT = process.env.PORT || 3000;
+const MONGO = process.env.MONGO_URI || 'mongodb://localhost:27017/automation';
+
+async function start() {
+  await mongoose.connect(MONGO);
+  await loadTasks();
+  app.listen(PORT, () => {
+    console.log(`Server listening on ${PORT}`);
+  });
+}
+
+start().catch(err => {
+  console.error(err);
+});

--- a/server/src/models/jobLog.ts
+++ b/server/src/models/jobLog.ts
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const jobLogSchema = new mongoose.Schema({
+  taskId: { type: mongoose.Schema.Types.ObjectId, ref: 'Task', required: true },
+  runAt: Date,
+  status: String,
+  outputSnippet: String,
+  errorMessage: String,
+}, { timestamps: true });
+
+export const JobLog = mongoose.model('JobLog', jobLogSchema);
+export type JobLogDocument = mongoose.InferSchemaType<typeof jobLogSchema>;

--- a/server/src/models/task.ts
+++ b/server/src/models/task.ts
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose';
+
+const platformSchema = new mongoose.Schema({
+  code: String,
+  config: mongoose.Schema.Types.Mixed,
+});
+
+const taskSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  name: String,
+  type: String,
+  freqCron: String,
+  promptTemplate: String,
+  variables: [String],
+  platforms: [platformSchema],
+  enabled: { type: Boolean, default: true },
+}, { timestamps: true });
+
+export const Task = mongoose.model('Task', taskSchema);
+export type TaskDocument = mongoose.InferSchemaType<typeof taskSchema>;

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema({
+  service: { type: String, required: true },
+  apiKeyEncrypted: { type: String, required: true },
+}, { timestamps: true });
+
+export const User = mongoose.model('User', userSchema);
+export type UserDocument = mongoose.InferSchemaType<typeof userSchema>;

--- a/server/src/routes/config.ts
+++ b/server/src/routes/config.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { User } from '../models/user';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  const { service, apiKey } = req.body;
+  const user = await User.create({ service, apiKeyEncrypted: apiKey });
+  res.json({ success: true, id: user.id });
+});
+
+export default router;

--- a/server/src/routes/platforms.ts
+++ b/server/src/routes/platforms.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+const router = Router();
+router.get('/', (req, res) => {
+  res.json([
+    { code: 'csdn', name: 'CSDN' },
+    { code: 'wechat', name: '微信公众号' },
+  ]);
+});
+
+export default router;

--- a/server/src/routes/tasks.ts
+++ b/server/src/routes/tasks.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import { Task } from '../models/task';
+import { scheduleTask, cancelTask } from '../services/scheduler';
+import { executeTask } from '../services/taskRunner';
+
+const router = Router();
+
+router.get('/', async (req, res) => {
+  const tasks = await Task.find();
+  res.json(tasks);
+});
+
+router.post('/', async (req, res) => {
+  const task = await Task.create(req.body);
+  if (task.enabled && task.freqCron) {
+    scheduleTask(task.id.toString(), task.freqCron);
+  }
+  res.json({ id: task.id });
+});
+
+router.put('/:id', async (req, res) => {
+  const task = await Task.findByIdAndUpdate(req.params.id, req.body, { new: true });
+  if (!task) return res.sendStatus(404);
+  if (task.enabled && task.freqCron) {
+    scheduleTask(task.id.toString(), task.freqCron);
+  } else {
+    cancelTask(task.id.toString());
+  }
+  res.json({ success: true });
+});
+
+router.delete('/:id', async (req, res) => {
+  await Task.findByIdAndDelete(req.params.id);
+  cancelTask(req.params.id);
+  res.json({ success: true });
+});
+
+router.post('/:id/execute', async (req, res) => {
+  await executeTask(req.params.id);
+  res.json({ success: true });
+});
+
+export default router;

--- a/server/src/services/openai.ts
+++ b/server/src/services/openai.ts
@@ -1,0 +1,14 @@
+import { Configuration, OpenAIApi } from 'openai';
+
+const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAIApi(configuration);
+
+export async function generateContent(prompt: string): Promise<string> {
+  const resp = await openai.createCompletion({
+    model: 'text-davinci-003',
+    prompt,
+    temperature: 0.7,
+    max_tokens: 1024,
+  });
+  return resp.data.choices[0]?.text || '';
+}

--- a/server/src/services/scheduler.ts
+++ b/server/src/services/scheduler.ts
@@ -1,0 +1,22 @@
+import schedule from 'node-schedule';
+import { Task } from '../models/task';
+import { executeTask } from './taskRunner';
+
+const jobs = new Map<string, schedule.Job>();
+
+export async function loadTasks() {
+  const tasks = await Task.find({ enabled: true });
+  tasks.forEach(t => scheduleTask(t.id.toString(), t.freqCron));
+}
+
+export function scheduleTask(id: string, cron: string) {
+  cancelTask(id);
+  const job = schedule.scheduleJob(cron, () => executeTask(id));
+  jobs.set(id, job);
+}
+
+export function cancelTask(id: string) {
+  const job = jobs.get(id);
+  if (job) job.cancel();
+  jobs.delete(id);
+}

--- a/server/src/services/taskRunner.ts
+++ b/server/src/services/taskRunner.ts
@@ -1,0 +1,27 @@
+import { Task } from '../models/task';
+import { JobLog } from '../models/jobLog';
+import { generateContent } from './openai';
+
+export async function executeTask(id: string) {
+  const task = await Task.findById(id);
+  if (!task) return;
+
+  const prompt = task.promptTemplate || '';
+  const runAt = new Date();
+  try {
+    const output = await generateContent(prompt);
+    await JobLog.create({
+      taskId: task.id,
+      runAt,
+      status: 'success',
+      outputSnippet: output.slice(0, 200),
+    });
+  } catch (err: any) {
+    await JobLog.create({
+      taskId: task.id,
+      runAt,
+      status: 'failed',
+      errorMessage: err.message,
+    });
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- implement server side skeleton with Express and MongoDB
- add API routes, models, scheduler and OpenAI service
- document server usage

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express', 'mongoose', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6827f0011cec832e9a84197583b6cb45